### PR TITLE
docs: document data access approaches in evaluations/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Submitted datasets should have a [Creative Commons CC-BY 4.0 license](https://cr
 
 A record of all current AIMIP-1 submissions — including participating groups, model names, experiment coverage, submitted grids, version labels, and example DKRZ file paths — is maintained in [SUBMISSIONS.md](SUBMISSIONS.md) at the root of this repository.
 
+For the different ways to access this data programmatically (local download, direct S3 reads, or the published intake catalog with kerchunk/icechunk leaves), see [evaluations/README.md § Data access approaches](evaluations/README.md#data-access-approaches).
+
 **Evaluation metrics**
 
 At a minimum, examine (for standard models):

--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -94,3 +94,77 @@ make execute   # execute all notebooks
 
 - `notebooks/aimip_data_utils.py` — data loading, regridding, and processing functions shared across notebooks
 - `notebooks/enso_index.py` — Niño3.4 ENSO index data and xarray conversion utilities
+
+## Data access approaches
+
+The evaluation notebooks above read data from **local files** that you download in advance — see [Data](#data) above. That's not the only way to consume AIMIP data, and it isn't always the right one. There are three complementary patterns, in increasing abstraction order.
+
+### 1. Local download (default for these E1–E5 notebooks)
+
+Pre-download a model submission with `s3fs.get(...)` or `aws s3 sync ...`, then point the notebooks at it via `AIMIP_DATA_ROOT`. Best when:
+
+- you re-read the same files many times (the evaluation notebooks do)
+- you want offline-capable, reproducible runs (e.g. CI)
+- network egress is expensive or slow
+
+Code: see [Data](#data) above.
+
+### 2. Direct S3 with classical `xarray`
+
+Open one NetCDF at a time, straight from S3, no local copy:
+
+```python
+import xarray as xr
+
+ds = xr.open_dataset(
+    "s3://ai-mip/Ai2/ACE2-1-ERA5/aimip/r1i1p1f1/Amon/tas/gn/v20251130/"
+    "tas_Amon_ACE2-1-ERA5_aimip_r1i1p1f1_gn_197810-202412.nc",
+    engine="h5netcdf",
+    backend_kwargs={"storage_options": {
+        "anon": True,
+        "client_kwargs": {"endpoint_url": "https://s3.eu-dkrz-1.dkrz.cloud"},
+    }},
+)
+```
+
+Best when: you already know the exact file path, you need just one file, or you're doing one-off exploratory work. End-to-end walkthrough: [`examples/working_with_AIMIP_data.ipynb`](../examples/working_with_AIMIP_data.ipynb).
+
+### 3. Cloud access via the intake catalog
+
+A virtual catalog published at `s3://ai-mip/catalog/` exposes every CMIP6 group as a single merged `xarray.Dataset`, with hierarchical browsing and rich metadata. Two leaves per group: a stock-zarr **kerchunk JSON** path and an **icechunk** path (which is the only published path for ~90 of the 239 stores — Ai2 day, all of DLESyM, Google day).
+
+```python
+import intake
+
+S3_OPTS = {"anon": True, "client_kwargs": {"endpoint_url": "https://s3.eu-dkrz-1.dkrz.cloud"}}
+cat = intake.open_catalog("s3://ai-mip/catalog/CMIP6/catalog.yaml", storage_options=S3_OPTS)
+
+# kerchunk JSON leaf (stock zarr; works for 149 of 239 stores)
+ds = cat['AIMIP']['NVIDIA']['cBottle-1-3']['aimip']['r1i1p4f1']['Amon']['gn'].to_dask()
+
+# icechunk leaf (works for all 239 stores; required for Ai2 day, DLESyM, Google day)
+ds = cat['AIMIP']['Ai2']['ACE2-1-ERA5']['aimip']['r1i1p1f1']['day']['gn_icechunk'].to_dask()
+```
+
+Best when: you want to discover what's available, slice by facets (`institution_id`, `experiment_id`, `variant_label`, …), or treat all variables of a group as one Dataset without manual concat. Multi-file groups, dropped-variable provenance, and version dedup are handled in the build. End-to-end walkthrough: [`examples/working_with_AIMIP_data_via_catalog.ipynb`](../examples/working_with_AIMIP_data_via_catalog.ipynb).
+
+### Picking an approach
+
+| Want to … | Best fit |
+|---|---|
+| Run E1–E5 here, or any workflow that re-reads files | **Local download** (default) |
+| Open one specific file by an exact path | Direct S3 |
+| Browse the archive hierarchically; multi-file groups as one Dataset | Catalog (kerchunk JSON) |
+| Read an Ai2 day, DLESyM, or Google day store | Catalog (icechunk — only published path for these) |
+
+### Install
+
+For (1) and (2): `pip install xarray s3fs h5netcdf` (already in `environment.yml`).
+
+For (3) the catalog:
+
+```bash
+pip install xarray intake intake-xarray kerchunk fsspec s3fs zarr jinja2 h5netcdf icechunk aimip-intake-icechunk
+```
+
+The catalog tooling is open-source ([source](https://github.com/koldunovn/aimip-data); [`aimip-intake-icechunk`](https://pypi.org/project/aimip-intake-icechunk/) on PyPI, MIT-licensed). A timed side-by-side comparison of the three approaches lives in [the catalog repo's `aimip_catalog_vs_classical.ipynb` notebook](https://github.com/koldunovn/aimip-data/blob/main/notebooks/aimip_catalog_vs_classical.ipynb).


### PR DESCRIPTION
Follow-up to #13. Addresses @brianhenn's review comment about wanting a single place that compares the different data access approaches.

## What this adds

**`evaluations/README.md` § Data access approaches** (at the end, after Utility Modules) covering three patterns with short examples and pointers to the example notebooks:

1. **Local download** — what these E1–E5 notebooks already do; reaffirms when this is the right default.
2. **Direct S3 with classical xarray** — links to `examples/working_with_AIMIP_data.ipynb`.
3. **Cloud access via the intake catalog** (kerchunk JSON + icechunk leaves) — links to `examples/working_with_AIMIP_data_via_catalog.ipynb` (added in #13).

Plus a small "Picking an approach" table and a per-approach install line so readers can copy-paste.

**Main `README.md`** gets a one-sentence pointer to that section, right after the SUBMISSIONS.md line, so paper readers landing on the root README can find the access patterns in one click.

## Why "Data access approaches" at the bottom of `evaluations/README.md`

Brian's suggestion was either the root README or the evaluations folder. The evaluations README is mostly setup-and-reproduction material; the new section is conceptually adjacent (how to get the data, then how to evaluate it) but a logical follow-up rather than prerequisite, so I put it at the end. The pointer in the root README ensures discoverability for readers who never make it into the eval folder.

## Test plan

- [x] Markdown renders cleanly (relative links, code blocks, table)
- [x] Anchor `evaluations/README.md#data-access-approaches` resolves from the root README link
- [x] All cross-links verified: examples/working_with_AIMIP_data.ipynb, examples/working_with_AIMIP_data_via_catalog.ipynb, the catalog repo, the PyPI page